### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.5'
   gem 'rails-controller-testing'
-  gem 'factory_girl_rails', '~> 4.0'
+  gem 'factory_bot_rails'
   gem 'faker'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,10 +68,10 @@ GEM
       html2haml
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
@@ -215,9 +215,6 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    turbolinks (5.2.0)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.19)
@@ -242,7 +239,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   erb2haml
-  factory_girl_rails (~> 4.0)
+  factory_bot_rails
   faker
   font-awesome-rails
   haml-rails
@@ -259,7 +256,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,54 @@
+$(function() {
+  $(document).on("click", ".user-search-add", function () {
+      var user_id = $(this).attr("data-user-id");
+      var user_name = $(this).attr("data-user-name");
+      selectUserName(user_id, user_name);
+      $(this).parent().remove();
+    })
+    $(document).on("click", ".user-search-remove", function () {
+      $(this).parent().remove();
+    })
+
+var search_list = $("#user-search-result");
+var select_list = $("#chat-group-users");
+
+function appendUserName(user) {
+   var html = `<div class="chat-group-user clearfix addmember">
+                <p class="chat-group-user__name">${ user.name }</p>
+                <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ user.id }"  data-user-name="${ user.name }">追加</a>
+              </div>`
+    search_list.append(html);
+  }
+
+function selectUserName(user_id, user_name) {
+   var remove_html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
+                        <input name='group[user_ids][]' type='hidden' value='${ user_id }'>
+                        <p class='chat-group-user__name'>${ user_name }</p>
+                        <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                    </div>`
+    select_list.append(remove_html);
+  }
+
+  $("#user-search-field").on("keyup", function() {
+    var input = $("#user-search-field").val();
+
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users) {
+      $("#user-search-result").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          appendUserName(user);
+        });
+      }
+    })
+    .fail(function() {
+      alert('ユーザー検索に失敗しました');
+    })
+  });
+});
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,14 @@ class UsersController < ApplicationController
     end
   end
 
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
+    @users = User.where('name LIKE(?) and id != ?', "%#{params[:keyword]}%" ,current_user)
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -15,7 +15,7 @@
       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+        = f.text_field :users, id: 'user-search-field', class: 'chat-group-form__input', type: 'text', value: '', placeholder: '追加したいユーザー名を入力してください'
       #user-search-result
 
   .chat-group-form__field.clearfix
@@ -24,7 +24,7 @@
     .chat-group-form__field--right
       #chat-group-users
         #chat-group-user-22.chat-group-user.clearfix
-          %input{:name => "group[user_ids][]", :type => "hidden", :value => "#{current_user.id}"}/
+          = f.text_field :users, type: "hidden", name: "group[user_ids][]" ,value: "#{current_user.id}"
           %p.chat-group-user__name
             = current_user.name
           %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,19 +12,19 @@
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      = f.label "チャットメンバーを追加", class: 'chat-group-form__label', for:'user-search-field'
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        = f.text_field :users, id: 'user-search-field', class: 'chat-group-form__input', type: 'text', value: '', placeholder: '追加したいユーザー名を入力してください'
+        = f.text_field :users, id: 'user-search-field', class: 'chat-group-form__input', value: '', placeholder: '追加したいユーザー名を入力してください'
       #user-search-result
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      = f.label "チャットメンバー", class: 'chat-group-form__label'
     .chat-group-form__field--right
       #chat-group-users
         #chat-group-user-22.chat-group-user.clearfix
-          = f.text_field :users, type: "hidden", name: "group[user_ids][]" ,value: "#{current_user.id}"
+          = f.hidden_field :users, name: "group[user_ids][]" ,value: "#{current_user.id}"
           %p.chat-group-user__name
             = current_user.name
           %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,31 +11,23 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      #chat-group-users
+        #chat-group-user-22.chat-group-user.clearfix
+          %input{:name => "group[user_ids][]", :type => "hidden", :value => "#{current_user.id}"}/
+          %p.chat-group-user__name
+            = current_user.name
+          %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,5 +1,4 @@
 json.array! @users do |user|
   json.id user.id
   json.name user.name
-  json.email user.email
 end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+  json.email user.email
+end

--- a/db/migrate/20181009033155_add_index_to_users.rb
+++ b/db/migrate/20181009033155_add_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_index :users,  :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180928110017) do
+ActiveRecord::Schema.define(version: 20181009033155) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20180928110017) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["name"], name: "index_users_on_name", using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :group do
     name Faker::Team.name
   end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :message do
     content Faker::Lorem.sentence
     image File.open("#{Rails.root}/public/images/no_image.jpg")

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     password = Faker::Internet.password(8)
     name Faker::Name.last_name

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ControllerMacros, type: :controller


### PR DESCRIPTION
# What
チャットグループの新規登録や編集をする際に、チャットメンバーの検索をインクリメンタルサーチし、候補を表示する。

# Why
検索を非同期で行えるようにすることで、検索をするたびに検索結果画面にリダイレクトしないようにし、ビューが毎回再描画されるのを防ぐ。